### PR TITLE
Offline support

### DIFF
--- a/source/DropboxDatasource.js
+++ b/source/DropboxDatasource.js
@@ -28,6 +28,9 @@ class DropboxDatasource extends TextDatasource {
      * @memberof DropboxDatasource
      */
     load(credentials) {
+        if (this.hasContent) {
+            return super.load(credentials);
+        }
         return new Promise((resolve, reject) => {
             this.dfs.readFile(this.path, { encoding: "utf8" }, function _readFile(error, data) {
                 if (error) {

--- a/source/FileDatasource.js
+++ b/source/FileDatasource.js
@@ -35,10 +35,12 @@ class FileDatasource extends TextDatasource {
      * @memberof FileDatasource
      */
     load(credentials) {
-        return this.readFile(this.path, "utf8").then(contents => {
-            this.setContent(contents);
-            return super.load(credentials);
-        });
+        return this.hasContent
+            ? super.load(credentials)
+            : this.readFile(this.path, "utf8").then(contents => {
+                  this.setContent(contents);
+                  return super.load(credentials);
+              });
     }
 
     /**

--- a/source/TextDatasource.js
+++ b/source/TextDatasource.js
@@ -86,6 +86,17 @@ class TextDatasource {
     }
 
     /**
+     * Whether the datasource currently has content
+     * Used to check if the datasource has encrypted content that can be loaded. May be used
+     * when attempting to open a vault in offline mode.
+     * @type {Boolean}
+     * @memberof TextDatasource
+     */
+    get hasContent() {
+        return this._content && this._content.length > 0;
+    }
+
+    /**
      * Load from the stored content using a password to decrypt
      * @param {Credentials} credentials The password or Credentials instance to decrypt with
      * @returns {Promise.<Array.<String>>} A promise that resolves with decrypted history

--- a/source/WebDAVDatasource.js
+++ b/source/WebDAVDatasource.js
@@ -56,10 +56,12 @@ class WebDAVDatasource extends TextDatasource {
      * @memberof WebDAVDatasource
      */
     load(credentials) {
-        return this.client.getFileContents(this.path, { format: "text" }).then(content => {
-            this.setContent(content);
-            return super.load(credentials);
-        });
+        return this.hasContent
+            ? super.load(credentials)
+            : this.client.getFileContents(this.path, { format: "text" }).then(content => {
+                  this.setContent(content);
+                  return super.load(credentials);
+              });
     }
 
     /**

--- a/test/FileDatasource.spec.js
+++ b/test/FileDatasource.spec.js
@@ -47,6 +47,16 @@ describe("FileDatasource", function() {
                     expect(archive.findGroupsByTitle("testGroup")).to.have.lengthOf(1);
                 });
         });
+
+        it("skips loading when content provided", function() {
+            const contents = fs.readFileSync(this.path, "utf8");
+            sinon.spy(this.datasource, "readFile");
+            this.datasource.setContent(contents);
+            return this.datasource.load(createCredentials.fromPassword("test")).then(history => {
+                expect(history).to.be.an("array");
+                expect(this.datasource.readFile.notCalled).to.be.true;
+            });
+        });
     });
 
     describe("save", function() {

--- a/test/WebDAVDatasource.spec.js
+++ b/test/WebDAVDatasource.spec.js
@@ -36,6 +36,7 @@ describe("WebDAVDatasource", function() {
                     createCredentials.fromPassword("test")
                 )
                 .then(encrypted => {
+                    this.encryptedContent = encrypted;
                     sinon
                         .stub(this.datasource.client, "getFileContents")
                         .returns(Promise.resolve(encrypted));
@@ -54,6 +55,14 @@ describe("WebDAVDatasource", function() {
                         format: "text"
                     })
                 ).to.be.true;
+            });
+        });
+
+        it("skips loading when content provided", function() {
+            this.datasource.setContent(this.encryptedContent);
+            return this.datasource.load(createCredentials.fromPassword("test")).then(history => {
+                expect(history).to.be.an("array");
+                expect(this.datasource.client.getFileContents.notCalled).to.be.true;
             });
         });
     });


### PR DESCRIPTION
Provides offline support by allowing content to be set in certain remote-type datasources. This allows them to bypass the remote fetch process when content is available offline (handled elsewhere).